### PR TITLE
Update marketfeed.ts

### DIFF
--- a/src/marketfeed.ts
+++ b/src/marketfeed.ts
@@ -47,6 +47,9 @@ class DhanSDKHelper {
         console.log(`WebSocket closed with status ${closeStatus}: ${closeMsg}`);
         websocket.close();
         this.sdkInstance.ws = null;
+        if (this.sdkInstance.onClose) {
+            await this.sdkInstance.onClose(this.sdkInstance);
+        }
     }
 }
 


### PR DESCRIPTION
- Issue : The callback onClose is not being called when the connection is closed, thus never letting the user know if the connection has been closed.
- Other workaround would have been to poll for dhanFeed.ws (currently being used by us, but that is not a clean method)